### PR TITLE
Allow underscores in upstream tarball names

### DIFF
--- a/{{cookiecutter.repo_name}}/debian/watch
+++ b/{{cookiecutter.repo_name}}/debian/watch
@@ -1,3 +1,3 @@
 version=3
 opts=uversionmangle=s/(rc|a|b|c)/~$1/ \
-https://pypi.debian.net/{{ cookiecutter.modulename }}/{{ cookiecutter.modulename }}-(.+)\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))
+https://pypi.debian.net/{{ cookiecutter.modulename }}/{{ cookiecutter.modulename | replace("-", "[-_]") }}-(.+)\.(?:zip|tgz|tbz|txz|(?:tar\.(?:gz|bz2|xz)))


### PR DESCRIPTION
Some upstream tarballs have underscores in the name of the tarball as opposed to hyphens. One such example is magnum-cluster-api which can be seen here:

https://pypi.debian.net/magnum-cluster-api/

This discrepancy makes uscan err out. This change allows both hyphens and underscores.